### PR TITLE
moved divRange declaration up to module

### DIFF
--- a/d3.slider.js
+++ b/d3.slider.js
@@ -45,6 +45,7 @@ return function module() {
       tickFormat = d3.format(".0"),
       handle1,
       handle2 = null,
+      divRange,
       sliderLength;
 
   function slider(selection) {
@@ -68,7 +69,7 @@ return function module() {
 
       // Slider handle
       //if range slider, create two
-      var divRange;
+      // var divRange;
 
       if ( value.length == 2 ) {
         handle1 = div.append("a")


### PR DESCRIPTION
Declaring divRange in the slider function was throwing an error when it was accessed in moveHandle().
