### PR TITLE
Vertical orientation slider needs to have minimum at the bottom

### DIFF
--- a/d3.slider.js
+++ b/d3.slider.js
@@ -135,7 +135,6 @@ return function module() {
 
         } else {
           handle1.style("bottom", formatPercent(scale(value)));
-          console.log("hello: "+scale(value));
           drag.on("drag", onDragVertical);
         }
         

--- a/d3.slider.js
+++ b/d3.slider.js
@@ -135,6 +135,7 @@ return function module() {
 
         } else {
           handle1.style("bottom", formatPercent(scale(value)));
+          console.log("hello: "+scale(value));
           drag.on("drag", onDragVertical);
         }
         
@@ -160,7 +161,10 @@ return function module() {
         }
 
         // Copy slider scale to move from percentages to pixels
-        axisScale = scale.ticks ? scale.copy().range([0, sliderLength]) : scale.copy().rangePoints([0, sliderLength], 0.5);
+        if(orientation == "horizontal")
+           axisScale = scale.ticks ? scale.copy().range([0,sliderLength]) : scale.copy().rangePoints([0,sliderLength], 0.5);  
+       else
+           axisScale = scale.ticks ? scale.copy().range([sliderLength, 0]) : scale.copy().rangePoints([sliderLength, 0], 0.5);
           axis.scale(axisScale);
 
           // Create SVG axis container


### PR DESCRIPTION
There was a wrong mapping of values in axes and the actual slider values. Plus the axes should have minimum at the bottom as it is more intuitive. 

I used the following code in my application and was facing problems which was solved later using the committed code.

d3.select('#Vslider').call(d3.slider().value(30).orientation("vertical").axis(true).min(-40).max(60).step(1).on("slide", function(evt, value) {
      console.log(value);
      d3.select('#Temperature').text(value)
      ;
      }));
