### PR TITLE
Custom scale support and sizing based on rendered container width

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+ {
+  "name": "d3.slider-megankanne",
+  "version": "0.1.1",
+  "description": "D3 slider forked from turban/d3.slider",
+  "main": [
+    "d3.slider.js",
+    "d3.slider.css"
+  ],
+  "dependencies": {
+    "d3": "~3.4.8"
+  },
+  "authors": [
+    "turban",
+    "megankanne"
+  ],
+  "license": "BSD",
+  "ignore": []
+}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
  {
-  "name": "d3.slider-megankanne",
-  "version": "0.1.1",
-  "description": "D3 slider forked from turban/d3.slider",
+  "name": "d3.slider",
+  "version": "0.1.0",
+  "description": "A pure D3.js slider inspired by the jQuery UI Slider",
   "main": [
     "d3.slider.js",
     "d3.slider.css"
@@ -10,8 +10,7 @@
     "d3": "~3.4.8"
   },
   "authors": [
-    "turban",
-    "megankanne"
+    "turban"
   ],
   "license": "BSD",
   "ignore": []


### PR DESCRIPTION
- Enables completely custom scales (eg. a polylinear scale) by only setting scale range if scale is not provided by user.
- Removes use of two scales ("scale" to map input value to slider width percentage and "axisScale" to map input value to slider pixel position). Replaces them with single scale mapping input value to slider pixel position and a function to translate that slider pixel position to a percentage of slider length.
- Removes requirement that container div has a css width style explicitly set. Instead, uses getBoundingClientRect() to determine the rendered width of the div.
- Adds automatic axis label wrapping using Mike's function from http://bl.ocks.org/mbostock/7555321
