### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "d3-slider",
+  "version": "0.1.0",
+  "homepage": "https://github.com/MasterMaps/d3-slider",
+  "authors": [
+    "Bjørn Sandvik <bjorn@mastermaps.com>"
+  ],
+  "description": "d3.js slider",
+  "main": [
+    "d3.slider.css",
+    "d3.slider.js"
+  ],
+  "moduleType": [
+    "amd",
+    "globals"
+  ],
+  "keywords": [
+    "d3",
+    "visualization"
+  ],
+  "license": "BSD",
+  "ignore": [
+    "**/.*",
+    "index.html"
+  ]
+}


### PR DESCRIPTION
This adds a `bower.json` file, which will make it easier for bower users to use `d3-slider` as a dependency.

I haven't added the project to the bower registry, that can be done with:

```
npm i -g bower
bower register d3.slider git://github.com/MasterMaps/d3-slider.git
```
